### PR TITLE
带默认值的注解解析

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 group 'com.github.zjb-it'
 version '9.0'
-
 repositories {
     repositories {
         maven { url 'http://maven.aliyun.com/nexus/content/groups/public/' }

--- a/src/main/java/com/github/zjb/GotoYmlFile.java
+++ b/src/main/java/com/github/zjb/GotoYmlFile.java
@@ -5,26 +5,18 @@ import com.google.common.collect.Lists;
 import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler;
 import com.intellij.ide.highlighter.JavaFileType;
 import com.intellij.lang.jvm.annotation.JvmAnnotationArrayValue;
-import com.intellij.lang.jvm.annotation.JvmAnnotationAttribute;
 import com.intellij.lang.jvm.annotation.JvmAnnotationAttributeValue;
 import com.intellij.lang.jvm.annotation.JvmAnnotationConstantValue;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
-import com.intellij.psi.impl.source.PsiJavaFileImpl;
-import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.psi.search.FileTypeIndex;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.tree.IElementType;
-import com.intellij.psi.util.JavaMatchers;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.yaml.YAMLFileType;
@@ -35,7 +27,6 @@ import org.jetbrains.yaml.psi.YAMLPsiElement;
 import org.jetbrains.yaml.psi.impl.YAMLPlainTextImpl;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * @author zhaojingbo(zjbhnay @ 163.com)
@@ -45,6 +36,7 @@ import java.util.stream.Collectors;
 public class GotoYmlFile implements GotoDeclarationHandler {
 
     private static final PsiElement[] DEFAULT_RESULT = new PsiElement[0];
+    public static final String DEFAULT_SPLIT = ":";
 
 
     @Nullable
@@ -123,8 +115,8 @@ public class GotoYmlFile implements GotoDeclarationHandler {
     private String getValueKey(String literalValue) {
         String valueKey = literalValue.substring(literalValue.indexOf("${") + 2, literalValue.indexOf("}"));
         //带有默认值的注解的解析，比如@Value("${a.b.c:123}")
-        if(valueKey.constains(":")){
-            valueKey = valueKey.split(":").get(0);
+        if(valueKey.contains(DEFAULT_SPLIT)){
+            valueKey = valueKey.split(DEFAULT_SPLIT)[0];
         }
         return valueKey;
     }

--- a/src/main/java/com/github/zjb/GotoYmlFile.java
+++ b/src/main/java/com/github/zjb/GotoYmlFile.java
@@ -102,7 +102,7 @@ public class GotoYmlFile implements GotoDeclarationHandler {
             if (!literalValue.startsWith("$")){
                 return false;
             }
-            String valueKey = literalValue.substring(literalValue.indexOf("${") + 2, literalValue.indexOf("}"));
+            String valueKey = getValueKey(literalValue);
             return Objects.equals(valueKey, configFullName);
         }
         if (constantValue instanceof JvmAnnotationArrayValue) {
@@ -118,6 +118,15 @@ public class GotoYmlFile implements GotoDeclarationHandler {
             }
         }
         return false;
+    }
+
+    private String getValueKey(String literalValue) {
+        String valueKey = literalValue.substring(literalValue.indexOf("${") + 2, literalValue.indexOf("}"));
+        //带有默认值的注解的解析，比如@Value("${a.b.c:123}")
+        if(valueKey.constains(":")){
+            valueKey = valueKey.split(":").get(0);
+        }
+        return valueKey;
     }
 
 

--- a/src/main/java/com/github/zjb/GotoYmlFile.java
+++ b/src/main/java/com/github/zjb/GotoYmlFile.java
@@ -79,7 +79,7 @@ public class GotoYmlFile implements GotoDeclarationHandler {
                     JvmAnnotationAttributeValue attributeValue = psiNameValuePair.getAttributeValue();
                     if (checkEquals(configFullName, attributeValue)) {
                         result.add(psiAnnotation);
-                        //æœ‰ä¸€ä¸ªç›¸ç­‰å°±ä¸åŒ¹é…å…¶å®ƒçš„äº†
+                        //ÓĞÒ»¸öÏàµÈ¾Í²»Æ¥ÅäÆäËüµÄÁË
                         break;
                     }
                 }
@@ -101,11 +101,11 @@ public class GotoYmlFile implements GotoDeclarationHandler {
             JvmAnnotationArrayValue attributeValue1 = (JvmAnnotationArrayValue) constantValue;
             List<JvmAnnotationAttributeValue> annotationArrayValues = attributeValue1.getValues();
             for (JvmAnnotationAttributeValue value : annotationArrayValues) {
-                //é€’å½’
+                //µİ¹é
                 if (checkEquals(configFullName, value)) {
                     return true;
                 }
-                //ä¸ç›¸ç­‰ï¼ŒåŒ¹é…ä¸‹ä¸€ä¸ª
+                //²»ÏàµÈ£¬Æ¥ÅäÏÂÒ»¸ö
                 continue;
             }
         }
@@ -114,7 +114,7 @@ public class GotoYmlFile implements GotoDeclarationHandler {
 
     private String getValueKey(String literalValue) {
         String valueKey = literalValue.substring(literalValue.indexOf("${") + 2, literalValue.indexOf("}"));
-        //å¸¦æœ‰é»˜è®¤å€¼çš„æ³¨è§£çš„è§£æï¼Œæ¯”å¦‚@Value("${a.b.c:123}")
+        //´øÓĞÄ¬ÈÏÖµµÄ×¢½âµÄ½âÎö£¬±ÈÈç@Value("${a.b.c:123}")
         if(valueKey.contains(DEFAULT_SPLIT)){
             valueKey = valueKey.split(DEFAULT_SPLIT)[0];
         }
@@ -133,7 +133,7 @@ public class GotoYmlFile implements GotoDeclarationHandler {
             return new PsiElement[0];
         }
         String key = sourceElement.getText();
-        key = key.substring(key.indexOf("${") + 2, key.indexOf("}"));
+        key = getValueKey(key);
         Project project = sourceElement.getProject();
         Collection<VirtualFile> files = FileTypeIndex.getFiles(YAMLFileType.YML, GlobalSearchScope.projectScope(project));
         if (CollectionUtils.isEmpty(files)) {


### PR DESCRIPTION
形如 @Value("${a.b.c:123}")的注解解析
![image](https://user-images.githubusercontent.com/9333625/120152334-ecf22900-c21f-11eb-8e67-82e795e2cc24.png)

在使用中发现如果注解中包含默认值，则跳转不生效。已修复并验证通过。